### PR TITLE
fix: correct GetDenomMetaData return value handling in migrator

### DIFF
--- a/x/tokenfactory/keeper/migrator.go
+++ b/x/tokenfactory/keeper/migrator.go
@@ -34,8 +34,8 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		denom := string(iter.Value())
-		denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, denom)
-		if err {
+		denomMetadata, found := m.keeper.bankKeeper.GetDenomMetaData(ctx, denom)
+		if !found {
 			panic(fmt.Errorf("denom %s does not exist", denom))
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `Migrate1to2` function in `x/tokenfactory/keeper/migrator.go` where the return value of `GetDenomMetaData` was incorrectly handled.

## The Bug

The bank keeper's `GetDenomMetaData` function returns `(banktypes.Metadata, bool)`, where the second value indicates whether the metadata was found. However, the migrator code was treating it as an error:

```go
// Before (incorrect)
denomMetadata, err := m.keeper.bankKeeper.GetDenomMetaData(ctx, denom)
if err {
    panic(fmt.Errorf("denom %s does not exist", denom))
}
